### PR TITLE
build(deps): bump file-type to ^16.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "agentkeepalive": "^4.1.4",
     "axios": "^0.21.1",
     "axios-cached-dns-resolve": "0.5.2",
-    "file-type": "16.5.3"
+    "file-type": "^16.5.4"
   }
 }


### PR DESCRIPTION
Hey! Ended up here after a dependabot ping in one of our private repos alerted us to the fact this this package currently depends on an insecure version of file-type. This PR upgrades file-type to a version patched against [CVE-2022-36313](https://github.com/advisories/GHSA-mhxj-85r3-2x55). Note that I didn't update package-lock.json in this PR, since it looks like it hasn't been updated in a while.

Looking through the code, I don't actually see where this package is used - perhaps instead we can consider removing this dependency entirely! Happy to change this PR to do that instead if you like.