### PR TITLE
fix: bump version to 0.0.7 to release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@trendyol-js/openstack-swift-sdk",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@trendyol-js/openstack-swift-sdk",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
         "agentkeepalive": "^4.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trendyol-js/openstack-swift-sdk",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Openstack Swift SDK",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
fix: bump version to 0.0.7 to release

Addresses -> https://github.com/Trendyol/openstack-swift-sdk/pull/8#issuecomment-1904705804